### PR TITLE
NPC Updates

### DIFF
--- a/db/item_db.conf
+++ b/db/item_db.conf
@@ -150872,6 +150872,27 @@ item_db: (
 
 //== New Etc Items =========================================
 {
+	Id: 22508
+	AegisName: "Para_Team_Mark_"
+	Name: "Eden Group Mark"
+	Type: 11
+	Buy: 0
+	Delay: 1200000
+	Trade: {
+		nodrop: true
+		notrade: true
+		noselltonpc: true
+		nocart: true
+		nostorage: true
+		nogstorage: true
+		nomail: true
+		noauction: true
+	}
+	Script: <"
+		unitskilluseid getcharid(3),"AL_TELEPORT",3;
+	">
+},
+{
 	Id: 22514
 	AegisName: "Candy_Holder"
 	Name: "Candy Holder"

--- a/npc/quests/eden/100-110.txt
+++ b/npc/quests/eden/100-110.txt
@@ -55,7 +55,7 @@ moc_para01,37,95,5	script	Gelkah#1	4_F_GELKA,{
 		end;
 	}
 	mes "[Gelkah]";
-	if (!countitem(Para_Team_Mark)) {
+	if (!countitem(Para_Team_Mark) && !countitem(Para_Team_Mark_)) {
 		mes "- You need to have an -";
 		mes "- ^4d4dff'Eden Group Mark'^000000 -";
 		mes "- to receive these missions. -";
@@ -1050,7 +1050,7 @@ S_Hunting:
 
 moc_para01,41,95,5	script	Rohtert#12	4_M_ROTERT,{
 	mes "[Rohtert]";
-	if (!countitem(Para_Team_Mark)) {// Para_Team_Mark
+	if (!countitem(Para_Team_Mark) && !countitem(Para_Team_Mark_)) {// Para_Team_Mark
 		cutin "rote01",2;
 		mes "You are not even a member of Eden Group. What are you doing here?";
 		mes "I'm only dealing with base level ^FF0000100 - 110^000000 adventurers.";

--- a/npc/quests/eden/11-25.txt
+++ b/npc/quests/eden/11-25.txt
@@ -38,7 +38,7 @@
 //=========================================================================
 
 moc_para01,36,38,3	script	Mission [11 - 25]#Tuto	4_BOARD3,{
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "- You need to have an -";
 		mes "- ^4d4dff'Eden Group Mark'^000000 -";
 		mes "- to receive these missions. -";

--- a/npc/quests/eden/111-120.txt
+++ b/npc/quests/eden/111-120.txt
@@ -44,7 +44,7 @@
 
 moc_para01,17,95,5	script	Mingmin#1	4_F_GENETIC,{
 	mes "[Mingmin]";
-	if (!countitem(Para_Team_Mark)) {// Para_Team_Mark
+	if (!countitem(Para_Team_Mark) && !countitem(Para_Team_Mark_)) {// Para_Team_Mark
 		cutin "min02",0;
 		mes "A stranger. This place is supposed to be for Eden Group Members only.";
 		mes "I'm in need base level ^FF0000111 - 120^000000 adventurers to help my research.";

--- a/npc/quests/eden/121-130.txt
+++ b/npc/quests/eden/121-130.txt
@@ -44,7 +44,7 @@
 
 moc_para01,44,81,3	script	Melody-Jack#1	4_M_MELODY,8,8,{
 	mes "[Melody-Jack]";
-	if (!countitem(Para_Team_Mark)) {// Para_Team_Mark
+	if (!countitem(Para_Team_Mark) && !countitem(Para_Team_Mark_)) {// Para_Team_Mark
 		mes "Who the hell are you? Get out of here!";
 		mes "I'm only talking to base level ^FF0000121-130^000000 adventurers.";
 	}
@@ -585,7 +585,7 @@ OnTouch:
 
 moc_para01,17,77,5	script	Aigu#1	4_F_IU,{
 	mes "[Aigu]";
-	if (!countitem(Para_Team_Mark)) {// Para_Team_Mark
+	if (!countitem(Para_Team_Mark) && !countitem(Para_Team_Mark_)) {// Para_Team_Mark
 		mes "Oh, why aren't you a part of Eden Group?";
 		mes "I'm only talking to base level ^FF0000121-130^000000 adventurers.";
 	}

--- a/npc/quests/eden/131-140.txt
+++ b/npc/quests/eden/131-140.txt
@@ -45,7 +45,7 @@
 moc_para01,41,76,3	script	Ragi#1	4_M_RAGI,{
 	cutin "ragi01",0;
 	mes "[Ragi]";
-	if (!countitem(Para_Team_Mark)) {// Para_Team_Mark
+	if (!countitem(Para_Team_Mark) && !countitem(Para_Team_Mark_)) {// Para_Team_Mark
 		mes "Only adventurers from Eden Group are welcome here.";
 		mes "I'm giving requests to base level ^FF0000130-140^000000 adventurers only.";
 	}

--- a/npc/quests/eden/26-40.txt
+++ b/npc/quests/eden/26-40.txt
@@ -38,7 +38,7 @@
 //=========================================================================
 
 moc_para01,38,38,3	script	Mission [26 - 40]	4_BOARD3,{
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "You are not a qualified member. You can not use the bulletin board.";
 		close;
 	}

--- a/npc/quests/eden/41-55.txt
+++ b/npc/quests/eden/41-55.txt
@@ -38,7 +38,7 @@
 //=========================================================================
 
 moc_para01,40,38,3	script	Mission [41 - 55]	4_BOARD3,{
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "You are not an Eden group member. You are not qualified to access the bulletin board.";
 		close;
 	}

--- a/npc/quests/eden/56-70.txt
+++ b/npc/quests/eden/56-70.txt
@@ -39,7 +39,7 @@
 //=========================================================================
 
 moc_para01,42,38,3	script	Mission [56 - 70]	4_BOARD3,{
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "To get these missions, I need to Join the Eden Group first. I must find Secretary Lime Evenor and become a member.";
 		close;
 	}

--- a/npc/quests/eden/71-85.txt
+++ b/npc/quests/eden/71-85.txt
@@ -38,7 +38,7 @@
 //=========================================================================
 
 moc_para01,44,38,3	script	Mission [71 - 85]	4_BOARD3,{
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "- Only members of the -";
 		mes "- Eden Group can read -";
 		mes "- this bulletin board. -";

--- a/npc/quests/eden/86-90.txt
+++ b/npc/quests/eden/86-90.txt
@@ -44,7 +44,7 @@
 //=========================================================================
 
 moc_para01,48,175,3	script	86-90 Mission Board	4_BOARD3,{
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "Wait a minute!";
 		mes "-You need to have an-";
 		mes "-^4d4dff'Eden Group Mark'^000000-";

--- a/npc/quests/eden/91-99.txt
+++ b/npc/quests/eden/91-99.txt
@@ -44,7 +44,7 @@
 //=========================================================================
 
 moc_para01,48,177,3	script	91-99 Mission Board	4_BOARD3,{
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "Wait a minute!";
 		mes "-You need to have an-";
 		mes "-^4d4dff'Eden Group Mark'^000000-";

--- a/npc/quests/eden/eden_common.txt
+++ b/npc/quests/eden/eden_common.txt
@@ -47,6 +47,26 @@ moc_para01,27,35,5	script	Secretary Lime Evenor	4_F_EDEN_OFFICER,{
 		mes "- after you loose some weight. -";
 		close;
 	}
+	if (countitem(Para_Team_Mark) > 0) {
+		mes "[Lime Evenor]";
+		mes "Thanks to many adventurers visiting our Eden Group, we've recently prepared a new version of Eden Group Mark for our visitors.";
+		mes "And it is also possible to exchange old version of Eden Group Mark into a new one.";
+		next;
+		mes "[Lime Evenor]";
+		mes "Though it has a slight time delay, this new version of Eden Group Mark will send you back to current saved location.";
+		mes "Would you like to exchange yours?";
+		next;
+		if (select("Sure", "I'm good.") == 2){
+			mes "[Lime Evenor]";
+			mes "What possible reason would you have... to not exchange?";
+			close;
+		}
+		delitem Para_Team_Mark,1;
+		getitem Para_Team_Mark_,1;
+		mes "[Lime Evenor]";
+		mes "There you go. Come back again~";
+		close;
+	}
 	mes "[Lime Evenor]";
 	mes "People who follow their dreams and romances listen to me. We are representatives of the paradise called 'The garden of Eden' called the Eden group . There is no place like this anywhere.";
 	mes "Hello. Can I help you?";
@@ -70,7 +90,7 @@ moc_para01,27,35,5	script	Secretary Lime Evenor	4_F_EDEN_OFFICER,{
 			next;
 			break;
 		case 2:
-			if (countitem(Para_Team_Mark) < 1) {
+			if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 				mes "[Lime Evenor]";
 				mes "You can be a Eden's member by simply registering with me.";
 				mes "Would you like to join Eden Group?";
@@ -109,7 +129,7 @@ moc_para01,27,35,5	script	Secretary Lime Evenor	4_F_EDEN_OFFICER,{
 					next;
 					mes "[Lime Evenor]";
 					mes "Hopefully you can do great work as an Eden's member.";
-					getitem Para_Team_Mark,1;
+					getitem Para_Team_Mark_,1;
 					next;
 					break;
 				case 2:
@@ -182,7 +202,7 @@ moc_para01,27,35,5	script	Secretary Lime Evenor	4_F_EDEN_OFFICER,{
 			}
 			break;
 		case 4:
-			if (countitem(Para_Team_Mark) > 0) {
+			if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 				mes "[Lime Evenor]";
 				mes "Would like to try some missions as an Eden member?";
 				next;
@@ -309,7 +329,7 @@ OnTouch:
 }
 
 moc_para01,47,39,3	script	#warp_2_pass	HIDDEN_NPC,{
-	if (countitem(Para_Team_Mark) > 0) {
+	if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 		mes "[Lime Evenor]";
 		mes "Oh, it is an exclusive place only for Eden's members.";
 		mes "If you are a member, you can come whenever you want!";

--- a/npc/quests/eden/eden_quests.txt
+++ b/npc/quests/eden/eden_quests.txt
@@ -40,7 +40,7 @@
 
 moc_para01,25,35,4	script	Instructor Boya#para01	4_M_KNIGHT_GOLD,{
 	mes "[Boya]";
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "You are not in my group are you?";
 		mes "I don't have anything to say to outsiders.";
 		mes "If you want something register with my group.";
@@ -842,7 +842,7 @@ moc_fild11,180,253,5	script	Talking Dog#para03	4_RUS_DWOLF,{
 	mes "Not a wolf.";
 	mes "I wasn't a dog originally...";
 	next;
-	if (countitem(Para_Team_Mark) > 0) {
+	if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 		mes "[Talking Dog]";
 		mes "Anyway are you a Eden Group member?";
 		mes "Oh good to see you.";
@@ -1050,7 +1050,7 @@ prt_sewb1,131,262,3	script	Timid Cat#para04	4_M_BABYCAT,{
 
 pay_arche,41,136,3	script	Eden Member Karl#para05	4_M_KHMAN,{
 	if (para_suv01 < 13) {
-		if (countitem(Para_Team_Mark) > 0) {
+		if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 			mes "[Karl]";
 			mes "Hey, how are you?";
 			mes "Good to see you~";
@@ -1193,7 +1193,7 @@ pay_arche,41,136,3	script	Eden Member Karl#para05	4_M_KHMAN,{
 
 anthell01,29,264,5	script	Eden Member Cloud#para06	4_M_HUMAN_02,{
 	if (para_suv01 < 17) {
-		if (countitem(Para_Team_Mark) > 0) {
+		if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 			mes "[Cloud]";
 			mes "Oops.";
 			mes "You are a member of my group.";
@@ -1383,7 +1383,7 @@ anthell01,29,264,5	script	Eden Member Cloud#para06	4_M_HUMAN_02,{
 
 in_orcs01,38,175,3	script	Eden Member Hooksha	1_F_SIGNZISK,{
 	if (para_suv01 < 24) {
-		if (countitem(Para_Team_Mark) > 0) {
+		if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 			mes "[Hooksha]";
 			mes "Unbelievable why did you come here?";
 			mes "Um... You are not on the third step of the training?";
@@ -1652,7 +1652,7 @@ in_orcs01,38,175,3	script	Eden Member Hooksha	1_F_SIGNZISK,{
 
 iz_dun04,43,46,3	script	Eden Member Callandiva	4_F_CRU,{
 	if (para_suv01 < 33) {
-		if (countitem(Para_Team_Mark) > 0) {
+		if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 			mes "[Callandiva]";
 			mes "How did you get so deep in this ocean city?";
 			mes "Ah, that symbol is of our group.";
@@ -2253,7 +2253,7 @@ moc_para01,179,44,3	script	Chef	4_M_CHNCOOK,{
 			mes "Ah, Kim-dduck-soon.";
 			mes "It's the representative meal for normal citizens.";
 			next;
-			if (countitem(Para_Team_Mark) > 0) {
+			if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 				if (Zeny > 2699) {
 					mes "[Chef]";
 					mes "Hey, here you are.";
@@ -2292,7 +2292,7 @@ moc_para01,179,44,3	script	Chef	4_M_CHNCOOK,{
 			mes "Course meal B?";
 			mes "This food with meat and vegetables in hot soup has it's origins from nomadic life under the cold and dry nature.";
 			next;
-			if (countitem(Para_Team_Mark) > 0) {
+			if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 				if (Zeny > 3599) {
 					mes "[Chef]";
 					mes "Hey, here you are.";
@@ -2327,7 +2327,7 @@ moc_para01,179,44,3	script	Chef	4_M_CHNCOOK,{
 			mes "How many times do I have to tell you?";
 			close;
 		case 4:
-			if (countitem(Para_Team_Mark) > 0) {
+			if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 				if (Zeny > 4499) {
 					mes "[Chef]";
 					mes "Hey, here you are.";
@@ -2370,7 +2370,7 @@ moc_para01,179,44,3	script	Chef	4_M_CHNCOOK,{
 			close;
 		}
 	case 2:
-		if (countitem(Para_Team_Mark) > 0) {
+		if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 			mes "[Chef]";
 			mes "Most jobs should be managed by yourself. So it might be difficult, right?";
 			mes "Actually it's harmful so they have requested continuously.";
@@ -2479,7 +2479,7 @@ moc_para01,179,44,3	script	Chef	4_M_CHNCOOK,{
 
 moc_para01,23,35,5	script	Instructor Ur#2nd01	4_M_KNIGHT_BLACK,{
 	mes "[Instructor Ur]";
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "Hey there!";
 		mes "I see you're not one of our agents?";
 		mes "Are you interested in joining us?";
@@ -3750,7 +3750,7 @@ moc_para01,111,83,3	script	Blacksmith Thorn#2nd10	2_M_OLDBLSMITH,{
 		close;
 	}
 	mes "[Thorn]";
-	if (countitem(Para_Team_Mark) < 1) {
+	if (countitem(Para_Team_Mark) < 1 && countitem(Para_Team_Mark_) < 1) {
 		mes "Hmm, are you a member of Eden Group?";
 		mes "You need to be one of our members to use my services.";
 		close;

--- a/npc/quests/eden/eden_service.txt
+++ b/npc/quests/eden/eden_service.txt
@@ -53,7 +53,7 @@
 	mes "3.Cabinet fee is";
 	mes "  ^4d4dff500 zeny^000000!";
 	next;
-	if (countitem(Para_Team_Mark) > 0) {
+	if (countitem(Para_Team_Mark) > 0 || countitem(Para_Team_Mark_) > 0) {
 		mes "You need to insert zeny to use the cabinet.";
 		mes "Cost : 500 Zeny ";
 		mes "Would you like to use it?";

--- a/npc/quests/quests_lighthalzen.txt
+++ b/npc/quests/quests_lighthalzen.txt
@@ -11831,6 +11831,12 @@ OnStop:
 	close;
 }
 
+izlude,172,73,5	duplicate(Scamp)	Scamp#iz	4_M_YURI
+izlude_a,172,73,5	duplicate(Scamp)	Scamp#iz_a	4_M_YURI
+izlude_b,172,73,5	duplicate(Scamp)	Scamp#iz_b	4_M_YURI
+izlude_c,172,73,5	duplicate(Scamp)	Scamp#iz_c	4_M_YURI
+izlude_d,172,73,5	duplicate(Scamp)	Scamp#iz_d	4_M_YURI
+
 airplane_01,1,1,1	script	#bully1	FAKE_NPC,{
 
 OnInit:


### PR DESCRIPTION
## NPC Updates

Added missed npc Scamp in location of Izlude from Shadow Quest (Rekember Quest)
Added support to Para_Team_Mark_ item in Eden Group

In 08/01/2012 Maintenance was added an improved version for Eden Group Mark:

"- Added exchange function for 'Lime Evenor' NPC where you can exchange 'Eden Group Mark' for a consumable item 'Eden Group Mark' with butterflywing-like function that can be used infinite number of times."
Source: http://forums.irowiki.org/index.php?topic=95103.0

This commit gives support to this new Eden Group Mark. All dialogues are official and have been taken from iRO.

If you need any reference about dialogues, can provide a replay using this npc and receiving this item in iRO.
